### PR TITLE
Fix script path typo in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         "scripts/plot_cross_phase_no_quant3.py",
         "scripts/poco_test_v3.py",
         "scripts/upload_fpga_py2.py",
-        "scripts/2d_beam_copy_cleaned.py3"
+        "scripts/2d_beam_copy_cleaned.py"
     ],
 )
 


### PR DESCRIPTION
Just fixing a small typo in the `setup.py` file that's preventing installation at the moment.

Without the patch I'm getting this error trying to install in a Python 3.8.13 environment:
```
$ pip install .
Processing /home/koopman/git/holog_daq
  Preparing metadata (setup.py) ... done
Building wheels for collected packages: holog-daq
  Building wheel for holog-daq (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py bdist_wheel did not run successfully.
  │ exit code: 1
  ╰─> [10 lines of output]
      running bdist_wheel
      running build
      running build_py
      running build_scripts
      copying scripts/poco_init.py3 -> build/scripts-3.8
      copying scripts/synth_init.py3 -> build/scripts-3.8
      copying scripts/plot_cross_phase_no_quant3.py -> build/scripts-3.8
      copying scripts/poco_test_v3.py -> build/scripts-3.8
      copying scripts/upload_fpga_py2.py -> build/scripts-3.8
      error: [Errno 2] No such file or directory: 'scripts/2d_beam_copy_cleaned.py3'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for holog-daq
  Running setup.py clean for holog-daq
Failed to build holog-daq
Installing collected packages: holog-daq
  Running setup.py install for holog-daq ... error
  error: subprocess-exited-with-error

  × Running setup.py install for holog-daq did not run successfully.
  │ exit code: 1
  ╰─> [18 lines of output]
      running install
      /home/koopman/git/holog_daq/.venv38/lib/python3.8/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
        warnings.warn(
      running build
      running build_py
      creating build/lib
      creating build/lib/holog_daq
      copying holog_daq/poco3.py -> build/lib/holog_daq
      copying holog_daq/fpga_daq3.py -> build/lib/holog_daq
      copying holog_daq/synth3.py -> build/lib/holog_daq
      running build_scripts
      creating build/scripts-3.8
      copying scripts/poco_init.py3 -> build/scripts-3.8
      copying scripts/synth_init.py3 -> build/scripts-3.8
      copying scripts/plot_cross_phase_no_quant3.py -> build/scripts-3.8
      copying scripts/poco_test_v3.py -> build/scripts-3.8
      copying scripts/upload_fpga_py2.py -> build/scripts-3.8
      error: file '/home/koopman/git/holog_daq/scripts/2d_beam_copy_cleaned.py3' does not exist
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: legacy-install-failure

× Encountered error while trying to install package.
╰─> holog-daq

note: This is an issue with the package mentioned above, not pip.
hint: See above for output from the failure.
```